### PR TITLE
Fix EasyAdmin error when trying to register. 

### DIFF
--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -7,8 +7,8 @@ use App\Entity\Zone;
 use App\Form\RegistrationFormType;
 use App\Security\EmailVerifier;
 use App\Repository\UserRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Mime\Address;
@@ -16,7 +16,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
 
-class RegistrationController extends AbstractController
+class RegistrationController extends AbstractDashboardController
 {
     private $emailVerifier;
 


### PR DESCRIPTION
I'm having the following error when accessing the `/register` page

<img width="1261" alt="Capture d’écran 2022-06-09 à 11 04 29" src="https://user-images.githubusercontent.com/1162230/172810806-793851cc-c1b0-4100-ab08-0fe77b07df66.png">


I fixed by extending `AbstractDashboardController` as recommended on EasyCorp/EasyAdminBundle#3317. I noticed `ResetPasswordController` also extends `AbstractDashboardController` so I guess it's ok?

