### PR TITLE
Implement OAuth authorization code grant

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,7 @@ REF: https://oauth2.thephpleague.com/installation/
     openssl genrsa -out private.key 2048
     chmod 660 private.key
     openssl rsa -in private.key -pubout -out public.key
+    chmod 660 public.key
 
     php -r 'echo base64_encode(random_bytes(32)), PHP_EOL;'
 

--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,7 @@
 REF: https://oauth2.thephpleague.com/installation/
 
     openssl genrsa -out private.key 2048
+    chmod 660 private.key
     openssl rsa -in private.key -pubout -out public.key
 
     php -r 'echo base64_encode(random_bytes(32)), PHP_EOL;'

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -39,7 +39,7 @@ security:
     # Note: Only the *first* access control that matches will be used
     access_control:
         - { path: ^/login, roles: PUBLIC_ACCESS }
-        - { path: ^/oauth2/authorize, roles: IS_AUTHENTICATED_REMEMBERED }
+        - { path: ^/oauth2/authorize, roles: IS_AUTHENTICATED_FULLY }
         - { path: ^/api/restaurants, roles: PUBLIC_ACCESS }
         - { path: ^/api/tags, roles: PUBLIC_ACCESS }
         - { path: ^/api/meal_types, roles: PUBLIC_ACCESS }

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -39,6 +39,7 @@ security:
     # Note: Only the *first* access control that matches will be used
     access_control:
         - { path: ^/login, roles: PUBLIC_ACCESS }
+        - { path: ^/oauth2/authorize, roles: IS_AUTHENTICATED_REMEMBERED }
         - { path: ^/api/restaurants, roles: PUBLIC_ACCESS }
         - { path: ^/api/tags, roles: PUBLIC_ACCESS }
         - { path: ^/api/meal_types, roles: PUBLIC_ACCESS }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -80,6 +80,15 @@ services:
     League\OAuth2\Server\Grant\RefreshTokenGrant:
         arguments:
             $refreshTokenRepository: '@App\Infrastructure\oAuth2Server\Bridge\RefreshTokenRepository'
+    oauth2.grants.auth_code.ttl:
+        class: \DateInterval
+        arguments:
+            - PT10M
+    League\OAuth2\Server\Grant\AuthCodeGrant:
+        arguments:
+            $authCodeRepository: '@App\Infrastructure\oAuth2Server\Bridge\AuthCodeRepository'
+            $refreshTokenRepository: '@App\Infrastructure\oAuth2Server\Bridge\RefreshTokenRepository'
+            $authCodeTTL: '@oauth2.grants.auth_code.ttl'
     App\MyResourceServer:
         arguments:
             $accessTokenRepository: '@App\Infrastructure\oAuth2Server\Bridge\AccessTokenRepository'

--- a/migrations/Version20220609105834.php
+++ b/migrations/Version20220609105834.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220609105834 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE auth_code (identifier VARCHAR(80) NOT NULL, client_id VARCHAR(255) DEFAULT NULL, expiry DATETIME NOT NULL, user_identifier VARCHAR(255) NOT NULL, revoked TINYINT(1) NOT NULL, INDEX IDX_5933D02C19EB6921 (client_id), PRIMARY KEY(identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE auth_code ADD CONSTRAINT FK_5933D02C19EB6921 FOREIGN KEY (client_id) REFERENCES client (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE auth_code');
+    }
+}

--- a/src/Controller/OAuth2Controller.php
+++ b/src/Controller/OAuth2Controller.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Controller;
+
+use App\Infrastructure\oAuth2Server\Bridge\User;
+use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\Grant\PasswordGrant;
+use League\OAuth2\Server\Grant\RefreshTokenGrant;
+use League\OAuth2\Server\Grant\AuthCodeGrant;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Zend\Diactoros\Response as Psr7Response;
+use Zend\Diactoros\Stream;
+use ApiPlatform\Core\Documentation\Documentation;
+
+/**
+ * @Route("/oauth2")
+ */
+final class OAuth2Controller extends AbstractController
+{
+    /**
+     * @var AuthorizationServer
+     */
+    private $authorizationServer;
+
+    /**
+     * @var PasswordGrant
+     */
+    private $passwordGrant;
+
+    /**
+     * @var RefreshTokenGrant
+     */
+    private $refreshTokenGrant;
+
+    /**
+     * AuthController constructor.
+     * @param AuthorizationServer $authorizationServer
+     * @param PasswordGrant $passwordGrant
+     * @param RefreshTokenGrant $refreshTokenGrant
+     */
+    public function __construct(
+        AuthorizationServer $authorizationServer,
+        PasswordGrant $passwordGrant,
+        RefreshTokenGrant $refreshTokenGrant,
+        AuthCodeGrant $authCodeGrant
+    ) {
+        $this->authorizationServer = $authorizationServer;
+        $this->passwordGrant = $passwordGrant;
+        $this->refreshTokenGrant = $refreshTokenGrant;
+        $this->authCodeGrant = $authCodeGrant;
+    }
+
+    /**
+     * @Route("/authorize", name="oauth2_authorize", methods={"GET"})
+     */
+    public function authorize(ServerRequestInterface $request): ?Psr7Response
+    {
+        $this->authCodeGrant->disableRequireCodeChallengeForPublicClients();
+
+        $this->authorizationServer->enableGrantType(
+            $this->authCodeGrant,
+            new \DateInterval('PT1H') // access tokens will expire after 1 hour
+        );
+
+        $response = new Psr7Response();
+
+        // https://oauth2.thephpleague.com/authorization-server/auth-code-grant/
+        try {
+
+            // Validate the HTTP request and return an AuthorizationRequest object.
+            $authRequest = $this->authorizationServer->validateAuthorizationRequest($request);
+
+            // The auth request object can be serialized and saved into a user's session.
+            // You will probably want to redirect the user at this point to a login endpoint.
+
+            // Once the user has logged in set the user on the AuthorizationRequest
+            $authRequest->setUser(new User('foo@bar.com')); // an instance of UserEntityInterface
+
+            // At this point you should redirect the user to an authorization page.
+            // This form will ask the user to approve the client and the scopes requested.
+
+            // Once the user has approved or denied the client update the status
+            // (true = approved, false = denied)
+            $authRequest->setAuthorizationApproved(true);
+
+            // Return the HTTP redirect response
+            return $this->authorizationServer->completeAuthorizationRequest($authRequest, $response);
+
+        } catch (OAuthServerException $exception) {
+
+            // All instances of OAuthServerException can be formatted into a HTTP response
+            return $exception->generateHttpResponse($response);
+
+        } catch (\Exception $exception) {
+
+            // Unknown exception
+            $body = new Stream(fopen('php://temp', 'r+'));
+            $body->write($exception->getMessage());
+
+            return $response->withStatus(500)->withBody($body);
+        }
+    }
+}

--- a/src/Controller/OAuth2Controller.php
+++ b/src/Controller/OAuth2Controller.php
@@ -78,7 +78,7 @@ final class OAuth2Controller extends AbstractController
             // You will probably want to redirect the user at this point to a login endpoint.
 
             // Once the user has logged in set the user on the AuthorizationRequest
-            $authRequest->setUser(new User('foo@bar.com')); // an instance of UserEntityInterface
+            $authRequest->setUser(new User($this->getUser()->getEmail())); // an instance of UserEntityInterface
 
             // At this point you should redirect the user to an authorization page.
             // This form will ask the user to approve the client and the scopes requested.

--- a/src/Controller/OAuth2Controller.php
+++ b/src/Controller/OAuth2Controller.php
@@ -79,7 +79,7 @@ final class OAuth2Controller extends AbstractController
             // You will probably want to redirect the user at this point to a login endpoint.
 
             // Once the user has logged in set the user on the AuthorizationRequest
-            $authRequest->setUser(new User($this->getUser()->getEmail())); // an instance of UserEntityInterface
+            $authRequest->setUser(new User($this->getUser()->getId())); // an instance of UserEntityInterface
 
             if ($form->isSubmitted() && $form->isValid()) {
 

--- a/src/Entity/AuthCode.php
+++ b/src/Entity/AuthCode.php
@@ -1,0 +1,93 @@
+<?php
+
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
+use League\OAuth2\Server\Entities\Traits\AuthCodeTrait;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+
+/**
+ * @ORM\Entity
+ */
+final class AuthCode
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string", length="80")
+     */
+    protected $identifier;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=Client::class)
+     */
+    protected $client;
+
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    protected $expiry;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    protected $userIdentifier;
+
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    protected $revoked = false;
+
+    public function __construct(
+        string $identifier,
+        Client $client,
+        \DateTimeImmutable $expiry,
+        string $userIdentifier)
+    {
+        $this->identifier = $identifier;
+        $this->client = $client;
+        $this->expiry = $expiry;
+        $this->userIdentifier = $userIdentifier;
+    }
+
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    public function setIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    public function getExpiryDateTime()
+    {
+        return $this->expiry;
+    }
+
+    public function setExpiryDateTime(\DateTimeImmutable $dateTime)
+    {
+        $this->expiry = $dateTime;
+    }
+
+    public function setUserIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    public function getUserIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    public function setClient(ClientEntityInterface $client)
+    {
+        $this->client = $client;
+    }
+}

--- a/src/Entity/AuthCode.php
+++ b/src/Entity/AuthCode.php
@@ -90,4 +90,14 @@ final class AuthCode
     {
         $this->client = $client;
     }
+
+    public function isRevoked()
+    {
+        return $this->revoked;
+    }
+
+    public function revoke()
+    {
+        $this->revoked = true;
+    }
 }

--- a/src/Form/AuthorizeForm.php
+++ b/src/Form/AuthorizeForm.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AuthorizeForm extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('approve', SubmitType::class, ['label' => 'Approve'])
+            ->add('deny', SubmitType::class, ['label' => 'Deny'])
+        ;
+    }
+}

--- a/src/Form/AuthorizeForm.php
+++ b/src/Form/AuthorizeForm.php
@@ -12,8 +12,8 @@ class AuthorizeForm extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('approve', SubmitType::class, ['label' => 'Approve'])
-            ->add('deny', SubmitType::class, ['label' => 'Deny'])
+            ->add('approve', SubmitType::class, ['label' => 'Accepter'])
+            ->add('deny', SubmitType::class, ['label' => 'Refuser'])
         ;
     }
 }

--- a/src/Infrastructure/oAuth2Server/Bridge/AuthCode.php
+++ b/src/Infrastructure/oAuth2Server/Bridge/AuthCode.php
@@ -1,0 +1,12 @@
+<?php
+namespace App\Infrastructure\oAuth2Server\Bridge;
+
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
+use League\OAuth2\Server\Entities\Traits\AuthCodeTrait;
+use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
+
+final class AuthCode implements AuthCodeEntityInterface
+{
+    use AuthCodeTrait, EntityTrait, TokenEntityTrait;
+}

--- a/src/Infrastructure/oAuth2Server/Bridge/AuthCodeRepository.php
+++ b/src/Infrastructure/oAuth2Server/Bridge/AuthCodeRepository.php
@@ -49,7 +49,10 @@ final class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function revokeAuthCode($codeId)
     {
+        $authCode = $this->authCodeRepository->find($codeId);
+        $authCode->revoke();
 
+        $this->authCodeRepository->save($authCode);
     }
 
     /**
@@ -57,6 +60,8 @@ final class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function isAuthCodeRevoked($codeId)
     {
+        $authCode = $this->authCodeRepository->find($codeId);
 
+        return $authCode->isRevoked();
     }
 }

--- a/src/Infrastructure/oAuth2Server/Bridge/AuthCodeRepository.php
+++ b/src/Infrastructure/oAuth2Server/Bridge/AuthCodeRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Infrastructure\oAuth2Server\Bridge;
+
+use App\Entity\AuthCode as AppAuthCode;
+use App\Repository\AuthCodeRepository as AppAuthCodeRepository;
+use App\Repository\ClientRepository as AppClientRepository;
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
+use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
+
+final class AuthCodeRepository implements AuthCodeRepositoryInterface
+{
+    /** @var AppAuthCodeRepository */
+    private $authCodeRepository;
+
+    public function __construct(AppAuthCodeRepository $authCodeRepository, AppClientRepository $clientRepository)
+    {
+        $this->authCodeRepository = $authCodeRepository;
+        $this->clientRepository = $clientRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNewAuthCode()
+    {
+        return new AuthCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function persistNewAuthCode(AuthCodeEntityInterface $authCodeEntity)
+    {
+        $client = $this->clientRepository->find($authCodeEntity->getClient()->getIdentifier());
+
+        $authCode = new AppAuthCode(
+            $authCodeEntity->getIdentifier(),
+            $client,
+            $authCodeEntity->getExpiryDateTime(),
+            $authCodeEntity->getUserIdentifier()
+        );
+
+        $this->authCodeRepository->save($authCode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function revokeAuthCode($codeId)
+    {
+
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAuthCodeRevoked($codeId)
+    {
+
+    }
+}

--- a/src/Repository/AuthCodeRepository.php
+++ b/src/Repository/AuthCodeRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\AuthCode;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class AuthCodeRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, AuthCode::class);
+    }
+
+    public function save(AuthCode $authCode): void
+    {
+        $this->_em->persist($authCode);
+        $this->_em->flush();
+    }
+}

--- a/templates/oauth2/authorize.html.twig
+++ b/templates/oauth2/authorize.html.twig
@@ -9,8 +9,8 @@
         {{ form_start(form) }}
             <p class="text-center mb-2">Autorisez-vous "{{ client_name }}" à gérer votre compte Dabba ?</p>
             <div class="flex flex-row gap-2">
-                {{ form_widget(form.approve, { attr: { class: 'bg-purple-600 hover:bg-purple-900 text-white font-bold p-2 rounded w-1/2' } }) }}
-                {{ form_widget(form.deny, { attr: { class: 'bg-purple-600 hover:bg-purple-900 text-white font-bold p-2 rounded w-1/2' } }) }}
+                {{ form_widget(form.deny, { attr: { class: 'bg-pink-600 hover:bg-pink-900 text-white font-bold p-2 rounded w-1/3' } }) }}
+                {{ form_widget(form.approve, { attr: { class: 'bg-purple-600 hover:bg-purple-900 text-white font-bold p-2 rounded w-2/3' } }) }}
             </div>
         {{ form_end(form) }}
         </div>

--- a/templates/oauth2/authorize.html.twig
+++ b/templates/oauth2/authorize.html.twig
@@ -4,8 +4,15 @@
 {% block title %}Authorize{% endblock %}
 
 {% block body %}
-    {{ form_start(form) }}
-        <p>Autorisez-vous "{{ client_name }}" à gérer votre compte Dabba ?</p>
-        {{ form_widget(form) }}
-    {{ form_end(form) }}
+    <div class="w-full sm:h-screen flex justify-center items-center bg-image bg-no-repeat bg-cover bg-center">
+        <div class="p-10 bg-white w-full sm:w-auto rounded flex justify-center items-center flex-col shadow-md">
+        {{ form_start(form) }}
+            <p class="text-center mb-2">Autorisez-vous "{{ client_name }}" à gérer votre compte Dabba ?</p>
+            <div class="flex flex-row gap-2">
+                {{ form_widget(form.approve, { attr: { class: 'bg-purple-600 hover:bg-purple-900 text-white font-bold p-2 rounded w-1/2' } }) }}
+                {{ form_widget(form.deny, { attr: { class: 'bg-purple-600 hover:bg-purple-900 text-white font-bold p-2 rounded w-1/2' } }) }}
+            </div>
+        {{ form_end(form) }}
+        </div>
+    </div>
 {% endblock %}

--- a/templates/oauth2/authorize.html.twig
+++ b/templates/oauth2/authorize.html.twig
@@ -1,0 +1,11 @@
+{% extends 'base.html.twig' %}
+{% form_theme form 'form_div_layout.html.twig' %}
+
+{% block title %}Authorize{% endblock %}
+
+{% block body %}
+    {{ form_start(form) }}
+        <p>Autorisez-vous "{{ client_name }}" à gérer votre compte Dabba ?</p>
+        {{ form_widget(form) }}
+    {{ form_end(form) }}
+{% endblock %}


### PR DESCRIPTION
This will display an authorization page so that the user can grant access to the OAuth client. 

Example OAuth URL:

```
http://localhost/oauth2/authorize?response_type=code&client_id=ClientId&redirect_uri=http://localhost/cb&scope=*
```

Once the user has approved the request, he/she will we redirected to the `redirect_uri` with a `code` parameter that allows to retrieve an access token. 

Example cURL request to retrieve an access token:

```
 curl -v -X POST -d 'grant_type=authorization_code&client_secret=ClientSecret&client_id=ClientId&redirect_uri=http://localhost/cb&code=<INSERT_AUTH_CODE_HERE>' http://localhost/oauth2/token
```

<img width="1026" alt="Capture d’écran 2022-06-10 à 09 47 46" src="https://user-images.githubusercontent.com/1162230/173017226-d5322329-c4c9-417e-a3e9-05555febd00d.png">



