### PR TITLE
Allow to refill wallet through authorization flow.

### DIFF
--- a/templates/oauth2/wallet.html.twig
+++ b/templates/oauth2/wallet.html.twig
@@ -1,0 +1,41 @@
+{% extends 'base.html.twig' %}
+
+{% block page_title 'OAuth2 wallet' %}
+
+{% block javascripts %}
+
+    {#
+    On success, this will redirect to the authorization page,
+    but *WITHOUT* the expected_wallet parameter.
+    This way, the authorization flow will continue.
+    #}
+    {% set query_params = app.request.query|filter((v, k) => k != 'expected_wallet')|merge([]) %}
+    {% set post_url_success = url(app.request.get('_route'), query_params) %}
+
+    <script
+        src="https://api.systempay.fr/static/js/krypton-client/V4.0/stable/kr-payment-form.min.js"
+        kr-public-key="{{ public_key }}"
+        kr-post-url-success="{{ post_url_success }}">
+    </script>
+{% endblock %}
+
+{% block body %}
+<div class="w-full sm:h-screen flex justify-center items-center bg-image bg-no-repeat bg-cover bg-center">
+    <div class="kr-embedded p-5 bg-white w-full"
+        kr-form-token="{{ form_token }}">
+
+        <h3>Veuillez recharger votre cagnotte pour continuer</h3>
+
+        <!-- payment form fields -->
+        <div class="kr-pan"></div>
+        <div class="kr-expiry"></div>
+        <div class="kr-security-code"></div>
+
+        <!-- payment form submit button -->
+        <button class="kr-payment-button rounded-full py-2 px-8 bg-purple-600 hover:bg-purple-900 text-white font-bold shadow-md w-full" ></button>
+
+        <!-- error zone -->
+        <div class="kr-form-error"></div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This will show a payment form to the user before showing the authorization form. 
This is implemented by adding a `expected_wallet` parameter to the authorize URL. 

![dabba_wallet](https://user-images.githubusercontent.com/1162230/176276741-5ffac9ea-46c8-42e2-9482-82c19a81cf1a.gif)
