### PR TITLE
Make it work when _target_path is passed as parameter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,7 +27,7 @@ You will need to define the `DATABASE_URL` variable like below (using a `.env.lo
 DATABASE_URL="mysql://dabba:dabba@mariadb:3306/dabba?serverVersion=10.3"
 ```
 
-When running the project for the the first time, you will need to create the database schema.
+When running the project for the first time, you will need to create the database schema.
 You can also create a user to access the admin area.
 
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,14 @@ You will need to define the `DATABASE_URL` variable like below (using a `.env.lo
 DATABASE_URL="mysql://dabba:dabba@mariadb:3306/dabba?serverVersion=10.3"
 ```
 
+When running the project for the the first time, you will need to create the database schema.
+You can also create a user to access the admin area.
+
+```
+docker-compose exec php bin/console doctrine:schema:create
+docker-compose exec php bin/console app:user:create --super-admin
+```
+
 composer install
 ```
 docker-compose exec php composer install

--- a/src/Command/UserCreateCommand.php
+++ b/src/Command/UserCreateCommand.php
@@ -149,9 +149,9 @@ class UserCreateCommand extends Command
         );
         
         if ($input->getOption('inactive')) {
-            $user->setEnabled(false);
+            $user->setIsVerified(false);
         } else {
-            $user->setEnabled(true);
+            $user->setIsVerified(true);
         }
         
         if ($input->getOption('super-admin')) {

--- a/templates/reset_password/request.html.twig
+++ b/templates/reset_password/request.html.twig
@@ -21,7 +21,7 @@
         {{ form_row(form._token) }}
         <div>
             <small>
-                Entre ton email et on t'envera un lien pour re-définir ton mot de passe.
+                Entre ton email et on t'enverra un lien pour re-définir ton mot de passe.
             </small>
         </div>
         <div class="text-center w-full">


### PR DESCRIPTION
The `_target_path` parameter is used in the [login form in the OAuth flow](https://github.com/janssens/dabba_API/blob/a52d3c1e6f1bd711ce904545ed138e1565710c5f/templates/oauth2/login_register.html.twig#L33), so that the OAuth flow continue seamlessly after login. 

But actually, it was not taken into account when passed as a parameter, because we are not using a `form_login`, but a guard authenticator directly. With this pull request, the `_target_path` parameter will be taken into account, and also the target path stored in session will continue to work as before. 